### PR TITLE
fix typo on section Update an existing row to an existing file

### DIFF
--- a/doc/source/tutorial_file.rst
+++ b/doc/source/tutorial_file.rst
@@ -61,7 +61,7 @@ Here is the code::
     | 12       | 11       | 10       |
     +----------+----------+----------+
 
-Update an exiting row to an existing file
+Update an existing row to an existing file
 -------------------------------------------
 
 Suppose you want to update the last row of the example file as:


### PR DESCRIPTION
fix a typo on section "Update an existing row to an existing file"
It is written "Update an exiting row to an existing file" but should be written "Update an exiSting row to an existing file"
Letter "s" is missing.